### PR TITLE
support rails 6.0 versions as well

### DIFF
--- a/pundit-resources.gemspec
+++ b/pundit-resources.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport"
   spec.add_dependency "jsonapi-resources"
   spec.add_dependency "pundit"
-  spec.add_dependency 'rails', '~> 6.1', '>= 6.1.4'
+  spec.add_dependency 'rails', '~> 6.0', '<= 6.1.4'
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
The need to use pundit-resources for rails 6.0 and above